### PR TITLE
text editor screen had transparent background

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -56,7 +56,7 @@
   }
 }
 
-:host, atom-text-editor .search-results .marker .region {
+atom-text-editor .search-results .marker .region {
   background-color: transparent;
   border: 1px solid @syntax-result-marker-color;
 }


### PR DESCRIPTION
Hi... For some reason having :host, was causing a the background of the text editor part of the screen to be transparent, and the default grey background from atom was showing through.

<img width="643" alt="screen shot 2017-01-13 at 10 34 24 am" src="https://cloud.githubusercontent.com/assets/5846846/21933458/e02883a4-d97b-11e6-848b-12158acc42e3.png">

<img width="333" alt="screen shot 2017-01-13 at 10 33 30 am" src="https://cloud.githubusercontent.com/assets/5846846/21933447/d6ff99b6-d97b-11e6-98f0-d3c083ac7dfb.png">
